### PR TITLE
Display Suite template for metadata pane

### DIFF
--- a/templates/ds-1col--node-dlts-book-metadata.php
+++ b/templates/ds-1col--node-dlts-book-metadata.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Display Suite 1 column template.
+ */
+?>
+<<?php print $ds_content_wrapper; print $layout_attributes; ?> class="ds-1col <?php print $classes;?> clearfix" dir="<?php print $lang_dir ?>" data-dir="<?php print $lang_dir ?>" data-lang="<?php print $lang_language ?>" >
+
+<?php if (isset($lang_options)) : ?><div class="lang-options"><?php print locale('Available languages', NULL, $lang_language) ?>: <?php print render($lang_options) ; ?></div><?php endif; ?>
+
+<?php print $ds_content; ?>
+
+ <?php if (isset($select_multivolbook)) : ?>
+    <div class="field field-name-field-title field-type-text field-label-inline clearfix">
+      <?php print $select_multivolbook; ?>
+    </div>
+  <?php endif; ?>
+
+<?php if (isset($rights)) : ?>
+    <div class="field field-name-field-rights field-type-text field-label-inline clearfix">
+      <?php print $rights; ?>
+    </div>
+<?php endif; ?>
+
+</<?php print $ds_content_wrapper ?>>
+
+<?php if (!empty($drupal_render_children)): ?>
+  <?php print $drupal_render_children ?>
+<?php endif; ?>
+


### PR DESCRIPTION
Here's the template that gets used by drupal for the metadata pane display when "display suite" module is enabled and selected layout is 1 column.
